### PR TITLE
Use copy_opts_to_assign in HTTP simulator routers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Workflow
+
+- Use `origin/master` as the comparison base for this workspace.
+- Prefer `rg` / `rg --files` for code search.
+- Keep generator changes aligned with the existing Igniter/template pattern:
+  - task code in `lib/mix/tasks/`
+  - templates in `priv/templates/sims.gen.<name>/`
+  - generator tests in `test/mix/tasks/`
+  - generated-app integration tests in `integration_test/test/sims/`
+
+## Verification
+
+- Run `mix deps.get` in the repo root if deps are missing.
+- Run `mix deps.get` separately in `integration_test/` before integration tests if needed.
+- For HTTP simulator generator template changes, verify both:
+  - `mix test`
+  - `cd integration_test && mix test`
+- Use `mix format --check-formatted` before finishing.
+
+## Generator Conventions
+
+- When changing emitted simulator code, test through generated-app integration tests, not only generator diff assertions.
+- When generated code starts relying on a library feature, update the generator's emitted dependency requirement to the minimum version that provides that feature, and add a generator test assertion for the emitted dependency.
+- Match established simulator templates before introducing new abstractions.
+- For generated Plug routers that need init opts, follow the current templates:
+  `use Plug.Router, copy_opts_to_assign: :init_opts`, an early `:unpack_opts`
+  plug, `Keyword.validate!`, and `merge_assigns/2`. Avoid custom `call/2`
+  overrides for this.

--- a/lib/mix/tasks/sims.gen.http_basic.ex
+++ b/lib/mix/tasks/sims.gen.http_basic.ex
@@ -91,7 +91,9 @@ defmodule Mix.Tasks.Sims.Gen.HttpBasic do
     |> copy_simulator_template("simulator/web_server/router.ex.eex", WebServer.Router)
     |> copy_simulator_template("simulator/web_server/responses.ex.eex", WebServer.Responses)
     |> Igniter.Project.Deps.add_dep({:bandit, "~> 1.0", only: :test}, append?: true)
-    |> Igniter.Project.Deps.add_dep({:plug, "~> 1.13", only: [:dev, :test]}, append?: true)
+    |> Igniter.Project.Deps.add_dep({:plug, ">= 1.13.3 and < 2.0.0", only: [:dev, :test]},
+      append?: true
+    )
     |> Igniter.Project.Formatter.import_dep(:plug)
     |> then(fn igniter ->
       if igniter.args.options[:include_app_config],

--- a/lib/mix/tasks/sims.gen.http_crud.ex
+++ b/lib/mix/tasks/sims.gen.http_crud.ex
@@ -97,7 +97,9 @@ defmodule Mix.Tasks.Sims.Gen.HttpCrud do
     |> copy_simulator_template("simulator/web_server/router.ex.eex", WebServer.Router)
     |> copy_simulator_template("simulator/web_server/responses.ex.eex", WebServer.Responses)
     |> Igniter.Project.Deps.add_dep({:bandit, "~> 1.0", only: :test}, append?: true)
-    |> Igniter.Project.Deps.add_dep({:plug, "~> 1.13", only: [:dev, :test]}, append?: true)
+    |> Igniter.Project.Deps.add_dep({:plug, ">= 1.13.3 and < 2.0.0", only: [:dev, :test]},
+      append?: true
+    )
     |> Igniter.Project.Formatter.import_dep(:plug)
     |> then(fn igniter ->
       if igniter.args.options[:include_app_config],

--- a/priv/templates/sims.gen.http_basic/simulator/web_server/router.ex.eex
+++ b/priv/templates/sims.gen.http_basic/simulator/web_server/router.ex.eex
@@ -1,11 +1,12 @@
 defmodule <%= inspect @module %> do
   @moduledoc false
 
-  use Plug.Router
+  use Plug.Router, copy_opts_to_assign: :init_opts
 
   alias <%= inspect @simulator.namespace %>.StateServer
   alias <%= inspect @simulator.namespace %>.WebServer.Responses
 
+  plug :unpack_opts
   plug :match
   plug :fetch_query_params
 
@@ -19,12 +20,10 @@ defmodule <%= inspect @module %> do
 
   plug :dispatch
 
-  def call(conn, opts) do
-    {state_server, opts} = Keyword.pop!(opts, :state_server)
-
-    conn
-    |> assign(:state_server, state_server)
-    |> super(opts)
+  defp unpack_opts(conn, _opts) do
+    conn.assigns.init_opts
+    |> Keyword.validate!([:state_server])
+    |> then(&merge_assigns(conn, &1))
   end
 
   get "/hello"<%= if @simulator.options.response_stubs? do %>, assigns: %{endpoint_id: :greeting}<% end %> do

--- a/priv/templates/sims.gen.http_crud/simulator/web_server/router.ex.eex
+++ b/priv/templates/sims.gen.http_crud/simulator/web_server/router.ex.eex
@@ -1,11 +1,12 @@
 defmodule <%= inspect @module %> do
   @moduledoc false
 
-  use Plug.Router
+  use Plug.Router, copy_opts_to_assign: :init_opts
 
   alias <%= @simulator.namespace %>.StateServer
   alias <%= @simulator.namespace %>.WebServer.Responses
 
+  plug :unpack_opts
   plug :match
   plug :fetch_query_params
 
@@ -22,12 +23,10 @@ defmodule <%= inspect @module %> do
 
   plug :dispatch
 
-  def call(conn, opts) do
-    {state_server, opts} = Keyword.pop!(opts, :state_server)
-
-    conn
-    |> assign(:state_server, state_server)
-    |> super(opts)
+  defp unpack_opts(conn, _opts) do
+    conn.assigns.init_opts
+    |> Keyword.validate!([:state_server])
+    |> then(&merge_assigns(conn, &1))
   end
 
   get "/<%= @model.plural %>", assigns: %{endpoint_id: :list_<%= @model.plural %>} do

--- a/test/mix/tasks/sims.gen.http_basic_test.exs
+++ b/test/mix/tasks/sims.gen.http_basic_test.exs
@@ -80,6 +80,7 @@ defmodule Mix.Tasks.Sims.Gen.HttpBasicTest do
 
     assert diff =~ "MyApp.PaymentGatewaySimulator"
     assert diff =~ "A Payment Gateway simulator"
+    assert diff =~ ~s({:plug, ">= 1.13.3 and < 2.0.0", only: [:dev, :test]})
   end
 
   test "handles namespaced simulator names" do

--- a/test/mix/tasks/sims.gen.http_crud_test.exs
+++ b/test/mix/tasks/sims.gen.http_crud_test.exs
@@ -80,6 +80,7 @@ defmodule Mix.Tasks.Sims.Gen.HttpCrudTest do
 
     assert diff =~ "MyApp.AddressBookSimulator"
     assert diff =~ "A Address Book simulator"
+    assert diff =~ ~s({:plug, ">= 1.13.3 and < 2.0.0", only: [:dev, :test]})
   end
 
   test "handles namespaced simulator names" do


### PR DESCRIPTION
## Summary
- Replace the manual `call/2` override in the `http_basic` and `http_crud` router templates with `use Plug.Router, copy_opts_to_assign: :init_opts` plus an early `:unpack_opts` plug that runs `Keyword.validate!/2` and `merge_assigns/2`.
- Add `AGENTS.md` documenting workflow, verification steps, and the canonical generator/router conventions.

## Test plan
- [ ] `mix test`
- [ ] `cd integration_test && mix test`
- [ ] `mix format --check-formatted`